### PR TITLE
Hide old pauses and scores

### DIFF
--- a/live-ticker/js/app.js
+++ b/live-ticker/js/app.js
@@ -47,12 +47,9 @@ async function init() {
 
   // Restore filter state
   const savedTeams = localStorage.getItem('lt_selectedTeams');
-  if (savedTeams) try { selectedTeams = new Set(JSON.parse(savedTeams)); } catch {}
+  if (savedTeams) try { selectedTeams = new Set(JSON.parse(savedTeams)); } catch { }
 
-  const sortedGroups = [...tournament.ageGroups].sort((g1, g2) =>
-      g1.label.localeCompare(g2.label, 'de', { numeric: true })
-    );
-  const allTabs = [INFO_TAB, ...sortedGroups];
+  const allTabs = [INFO_TAB, ...(tournament.ageGroups)];
 
   if (allTabs.length > 0) {
     const saved = localStorage.getItem('tw_activeTab');
@@ -120,7 +117,7 @@ async function loadGroup(groupId) {
 
 function applyFilter(teams) {
   selectedTeams = teams;
-  try { localStorage.setItem('lt_selectedTeams', JSON.stringify([...selectedTeams])); } catch {}
+  try { localStorage.setItem('lt_selectedTeams', JSON.stringify([...selectedTeams])); } catch { }
   renderFilterTags(selectedTeams, removeTeamFilter);
   if (currentMatches) {
     renderMatches(filterMatches(currentMatches, selectedTeams));

--- a/live-ticker/js/render.js
+++ b/live-ticker/js/render.js
@@ -37,7 +37,8 @@ export function renderTabs(ageGroups, activeId, onSwitch) {
 
 export function renderMatches(matches, pauseTimes) {
   hideLoading();
-  const mergedPauses = mergePauses(pauseTimes || []);
+  const now = Date.now();
+  const mergedPauses = mergePauses(pauseTimes || []).filter(p => p.endTime > now);
   const allItems = [...(matches || []), ...mergedPauses];
 
   if (allItems.length === 0) {
@@ -120,7 +121,7 @@ function createMatchCard(match) {
   const card = document.createElement('article');
   card.className = `match-card ${getStatusClass(match.status)}`;
 
-  const showScore = match.status === 'live' || match.status === 'completed';
+  const showScore = false
   const scoreHTML = showScore
     ? `<div class="match-card__score">${formatScore(match.scoreA, match.scoreB)}</div>`
     : `<div class="match-card__vs">vs</div>`;


### PR DESCRIPTION
- Scores waren bei mir nicht immer da und jetzt will ich nichts mehr fixen, sondern anzeigen was zuverlässig geht und darauf für nächstes Jahr aufbauen.
- Alte Pausen werden jetzt einfach rausgefiltert
- Beim Klicken ändert sich die Reihenfolge der Tabs